### PR TITLE
Feature/empty tooltip removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gns-science/toshi-nest",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "The toshi-nest is for fledgling work e.g. reusable Node components to share across TUI and other projects",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/GroupCurveChart/GroupCurveChart.tsx
+++ b/src/GroupCurveChart/GroupCurveChart.tsx
@@ -123,7 +123,7 @@ const GroupCurveChart: React.FC<GroupCurveChartProps> = (props: GroupCurveChartP
     tooltipLeft = 0,
     tooltipTop = 0,
   } = useTooltip<Datum>({
-    tooltipOpen: true,
+    tooltipOpen: false,
   });
 
   const meanCurves = useMemo(() => getSortedMeanCurves(curves), [curves]);


### PR DESCRIPTION
empty tooltip no longer appears on hazard chart before mousing over;