### PR TITLE
fix: format axis tick labels as plain numbers and tune default tick counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.2] - 2026-03-17
+
+### Changed
+ - GroupCurveChart: format axis ticks as plain numbers to avoid scientific notation
+ - GroupCurveChart: default number of x-axis ticks depends on axis type (log or linear)
+
 ## [0.4.1] - 2025-12-01
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,57 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+`toshi-nest` (`@gns-science/toshi-nest`) is a React component library published to GitHub's NPM registry, providing shared UI components for GNS Science projects (primarily Kororaa and TUI apps). It outputs both CJS and ESM bundles via Rollup.
+
+## Commands
+
+```bash
+yarn build           # Build the library (Rollup, outputs CJS + ESM)
+yarn build-watch     # Build in watch mode
+yarn test            # Run all tests (Jest)
+yarn test:watch      # Run tests in watch mode
+yarn lint            # ESLint with auto-fix
+yarn storybook       # Start Storybook dev server on port 6006
+yarn build-storybook # Build static Storybook
+```
+
+**Run a single test file:**
+```bash
+yarn test SelectControl.test.tsx
+# or with pattern matching:
+yarn test --testPathPattern=HazardChart
+```
+
+## Architecture
+
+The library is organized around four main component categories:
+
+- **Controls** (`src/controls/`) — `SelectControl`, `MultiSelect`, `RangeSliderWithInputs`, `ControlsBar`
+- **Charts** (`src/hazardCharts/`, `src/spectralAccelChart/`, `src/groupCurveChart/`, `src/disaggregationChart/`, `src/mfdPlot/`) — Visx-based SVG charts, each with a `*Responsive` wrapper variant that uses Visx's `ParentSize`
+- **Maps** (`src/LeafletMap/`, `src/leafletDrawer/`, `src/TimeDimensionLayer/`) — Leaflet + react-leaflet, with a custom `TimeDimensionLayer` for animated temporal data
+- **Tables** (`src/faultModelTable/`) — MUI DataGrid-based table
+
+Shared components live in `src/common/` (e.g., `AxisLabel`, `ControlsBar`, `PlotHeadings`). TypeScript types shared across components are in `src/types/`.
+
+`src/index.ts` is the single export entry point — all public components must be re-exported from here.
+
+Each component folder typically contains:
+- `ComponentName.tsx` — main component
+- `ComponentName.stories.tsx` — Storybook story
+- `ComponentName.test.tsx` — Jest/RTL tests (not all components have tests)
+- `ComponentName.types.ts` — component-specific types
+- `index.ts` — re-export
+
+## Key Dependencies & Pinned Versions
+
+- **Charts**: Visx (`@visx/*`) — primary charting library; Plotly.js for `MfdPlot`
+- **Maps**: `react-leaflet` pinned at **3.2.5** (TimeDimensionLayer breaks in 4.0.0+)
+- **UI**: MUI v7 with `@mui/x-data-grid`
+- **`ansi-styles`** pinned at 5.2.0 and **`strip-indent`** pinned at 3.0.0 (ESM compatibility)
+
+## Testing Notes
+
+Tests use Jest + React Testing Library with a jsdom environment. `src/setupTests.ts` sets up a `ResizeObserver` polyfill (needed for Visx/chart components) and `@testing-library/jest-dom` matchers. Tests are co-located with components.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gns-science/toshi-nest",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "The toshi-nest is for fledgling work e.g. reusable Node components to share across TUI and other projects",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/GroupCurveChart/GroupCurveChart.tsx
+++ b/src/GroupCurveChart/GroupCurveChart.tsx
@@ -50,6 +50,7 @@ const GroupCurveChart: React.FC<GroupCurveChartProps> = (props: GroupCurveChartP
   const marginBottom = 50;
   const xMax = width - marginLeft - marginRight;
   const yMax = height - marginBottom - marginTop;
+  const autoNumTickX = scaleType === 'log' ? 3 : 5;
 
   const [boxPlotToolTipActive, setBoxPlotToolTipActive] = useState(false);
 
@@ -241,8 +242,8 @@ const GroupCurveChart: React.FC<GroupCurveChartProps> = (props: GroupCurveChartP
           <AxisLabel label={xLabel as string} width={width} height={height} orientation="bottom" />
           <AxisLabel label={yLabel as string} width={width} height={height} orientation="left" />
           <Group left={marginLeft} top={marginTop}>
-            <AxisBottom top={yMax} scale={xScale} numTicks={numTickX ?? 5} stroke={gridColor} tickLength={3} tickStroke={gridColor} />
-            <AxisLeft scale={yScale} numTicks={numTickY ?? 5} stroke={gridColor} tickLength={3} tickStroke={gridColor} />
+            <AxisBottom top={yMax} scale={xScale} numTicks={numTickX ?? autoNumTickX} stroke={gridColor} tickLength={3} tickStroke={gridColor} tickFormat={(v) => `${v.valueOf()}`} />
+            <AxisLeft scale={yScale} numTicks={numTickY ?? 5} stroke={gridColor} tickLength={3} tickStroke={gridColor} tickFormat={(v) => `${v.valueOf()}`} />
             <GridColumns scale={xScale} width={xMax} height={yMax} stroke={gridColor ?? '#efefef'} />
             <GridRows scale={yScale} width={xMax} height={yMax} stroke={gridColor ?? '#efefef'} />
             <RectClipPath id="uncertainty-clip" height={yMax} width={xMax} />

--- a/src/GroupCurveChartResponsive/GroupCurveChartResponsive.stories.tsx
+++ b/src/GroupCurveChartResponsive/GroupCurveChartResponsive.stories.tsx
@@ -13,6 +13,7 @@ export default {
 const Template: ComponentStory<typeof GroupCurveChartResponsive> = (args) => <GroupCurveChartResponsive {...args} />;
 
 export const Primary = Template.bind({});
+export const AutoXTick = Template.bind({});
 export const SpectralAccelUncertaintyTrue = Template.bind({});
 export const SpectralAccelUncertaintyFalse = Template.bind({});
 
@@ -25,6 +26,24 @@ Primary.args = {
   gridColor: '#efefef',
   backgroundColor: '#ffffff',
   numTickX: 5,
+  numTickY: 5,
+  curves: { curveGroup1: curveGroup1, curveGroup2: curveGroup2 },
+  tooltip: true,
+  crosshair: true,
+  heading: 'Hazard Chart with Uncertainty',
+  subHeading: 'WLG 250',
+  poe: 0.02,
+  timePeriod: 100,
+};
+
+AutoXTick.args = {
+  scaleType: 'log',
+  xLimits: [1e-2, 10],
+  yLimits: [1e-6, 1],
+  xLabel: 'Acceleration(g)',
+  yLabel: 'Annual Probability of Exceedance',
+  gridColor: '#efefef',
+  backgroundColor: '#ffffff',
   numTickY: 5,
   curves: { curveGroup1: curveGroup1, curveGroup2: curveGroup2 },
   tooltip: true,

--- a/src/HazardChart/HazardChart.test.tsx
+++ b/src/HazardChart/HazardChart.test.tsx
@@ -31,7 +31,7 @@ describe('Hazard Curves works as expected', () => {
     expect(screen.getByText('Acceleration (g)')).toBeInTheDocument();
     expect(screen.getByText('Annual Probability of Exceedance')).toBeInTheDocument();
     expect(screen.getByText('PGA')).toBeInTheDocument();
-    expect(screen.getByText('0.1')).toBeInTheDocument();
+    expect(screen.getAllByText('0.1').length).toBeGreaterThan(0);
   });
 
   test('two curves are printed', async () => {

--- a/src/HazardChart/HazardChart.test.tsx
+++ b/src/HazardChart/HazardChart.test.tsx
@@ -19,7 +19,7 @@ const scalesConfig: XYChartScaleConfig = {
 describe('Hazard Curves works as expected', () => {
   const Wrapper = () => {
     return (
-      <HazardChart curves={testData} width={500} scalesConfig={scalesConfig} colors={colors} heading={'Test Heading'} subHeading={'Test Subheading'} gridNumTicks={5} poe={undefined} timePeriod={50} />
+      <HazardChart curves={testData} width={500} scalesConfig={scalesConfig} colors={colors} heading={'Test Heading'} subHeading={'Test Subheading'} gridNumTicks={3} poe={undefined} timePeriod={50} />
     );
   };
   userEvent.setup();

--- a/src/HazardChart/HazardChart.tsx
+++ b/src/HazardChart/HazardChart.tsx
@@ -48,8 +48,8 @@ const HazardChart: React.FC<HazardChartProps> = (props: HazardChartProps) => {
       <div style={{ position: 'relative', width: width }}>
         <XYChart height={width * 0.75} width={width} xScale={scalesConfig.x} yScale={scalesConfig.y}>
           <PlotHeadings heading={heading} subHeading={subHeading} width={width} />
-          <AnimatedAxis label="Acceleration (g)" orientation="bottom" />
-          <AnimatedAxis label={`Annual Probability of Exceedance`} labelOffset={20} orientation="left" />
+          <AnimatedAxis label="Acceleration (g)" orientation="bottom" tickFormat={(v: number) => `${v}`} />
+          <AnimatedAxis label={`Annual Probability of Exceedance`} labelOffset={20} orientation="left" tickFormat={(v: number) => `${v}`} />
           <Grid rows columns lineStyle={{ opacity: '90%' }} numTicks={gridNumTicks} />
           <RectClipPath id={parentRef ? 'responsive-clip' : 'clip'} x={50} y={-50} width={width} height={width * 0.75} />
           <Group clipPath={parentRef ? 'url(#responsive-clip)' : 'url(#clip)'}>


### PR DESCRIPTION
closes #169 

Fixes axis labels on HazardChart and GroupCurveChart that were rendering in scientific notation (e.g. `m`, `μ`). Adds a tickFormat to both axes on each chart to force plain number display. Also sets the default number of X-axis ticks on GroupCurveChart to 3 for log scales and 5 for linear.