### PR TITLE
Fix chalk/ansi-styles version conflict breaking yarn test

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,7 +10,7 @@ export default {
     '^.+\\.(ts|js)x?$': 'ts-jest',
   },
   transformIgnorePatterns: ['<rootDir>/node_modules/(?!d3-array|internmap|d3-interpolate|d3-scale|d3-selection|d3-shape|d3-axis|d3-color|d3-format|d3-time|d3-time-format)'],
-  moduleDirectories: ['<rootDir>/node_modules', '<rootDir>/src'],
+  moduleDirectories: ['node_modules', '<rootDir>/src'],
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
   // All imported modules in your tests should be mocked automatically
   // automock: false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gns-science/toshi-nest",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "The toshi-nest is for fledgling work e.g. reusable Node components to share across TUI and other projects",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,6 @@
     "react-spring": "^10.0.3"
   },
   "resolutions": {
-    "ansi-styles": "5.2.0",
     "strip-indent": "3.0.0"
   },
   "packageManager": "yarn@4.11.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5407,10 +5407,33 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ansi-styles@npm:5.2.0":
+"ansi-styles@npm:^2.2.1":
+  version: 2.2.1
+  resolution: "ansi-styles@npm:2.2.1"
+  checksum: 10c0/7c68aed4f1857389e7a12f85537ea5b40d832656babbf511cc7ecd9efc52889b9c3e5653a71a6aade783c3c5e0aa223ad4ff8e83c27ac8a666514e6c79068cab
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^4.0.0, ansi-styles@npm:^4.1.0":
+  version: 4.3.0
+  resolution: "ansi-styles@npm:4.3.0"
+  dependencies:
+    color-convert: "npm:^2.0.1"
+  checksum: 10c0/895a23929da416f2bd3de7e9cb4eabd340949328ab85ddd6e484a637d8f6820d485f53933446f5291c3b760cbc488beb8e88573dd0f9c7daf83dccc8fe81b041
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^5.0.0, ansi-styles@npm:^5.2.0":
   version: 5.2.0
   resolution: "ansi-styles@npm:5.2.0"
   checksum: 10c0/9c4ca80eb3c2fb7b33841c210d2f20807f40865d27008d7c3f707b7f95cab7d67462a565e2388ac3285b71cb3d9bb2173de8da37c57692a362885ec34d6e27df
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^6.1.0, ansi-styles@npm:^6.2.1":
+  version: 6.2.3
+  resolution: "ansi-styles@npm:6.2.3"
+  checksum: 10c0/23b8a4ce14e18fb854693b95351e286b771d23d8844057ed2e7d083cd3e708376c3323707ec6a24365f7d7eda3ca00327fe04092e29e551499ec4c8b7bfac868
   languageName: node
   linkType: hard
 
@@ -6210,6 +6233,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"color-convert@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "color-convert@npm:2.0.1"
+  dependencies:
+    color-name: "npm:~1.1.4"
+  checksum: 10c0/37e1150172f2e311fe1b2df62c6293a342ee7380da7b9cfdba67ea539909afbd74da27033208d01d6d5cfc65ee7868a22e18d7e7648e004425441c0f8a15a7d7
+  languageName: node
+  linkType: hard
+
 "color-id@npm:^1.1.0":
   version: 1.1.0
   resolution: "color-id@npm:1.1.0"
@@ -6219,7 +6251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"color-name@npm:^1.0.0":
+"color-name@npm:^1.0.0, color-name@npm:~1.1.4":
   version: 1.1.4
   resolution: "color-name@npm:1.1.4"
   checksum: 10c0/a1a3f914156960902f46f7f56bc62effc6c94e84b2cae157a526b1c1f74b677a47ec602bf68a61abfa2b42d15b7c5651c6dbe72a43af720bc588dff885b10f95


### PR DESCRIPTION
Removed the global `ansi-styles: 5.2.0` resolution from package.json. That forced chalk@4 (which requires ^4.1.0) to use an incompatible v5, causing a TypeError on terminals with basic ANSI colour support.

Also fixed jest.config.ts moduleDirectories from '<rootDir>/node_modules' (absolute path, bypasses nested resolution) to 'node_modules' (relative, uses standard Node.js traversal). The absolute form caused Jest to load the hoisted ansi-styles@6 (pure ESM) for pretty-format instead of its nested ansi-styles@5, producing a SyntaxError in Jest's CJS mode.

With both changes, Yarn resolves chalk@4→ansi-styles@4, pretty-format→ ansi-styles@5, and Jest's module resolver correctly follows nested node_modules installs. All 8 test suites now pass.