### PR TITLE
Fix/172 y tick labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gns-science/toshi-nest",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "The toshi-nest is for fledgling work e.g. reusable Node components to share across TUI and other projects",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/GroupCurveChart/GroupCurveChart.stories.tsx
+++ b/src/GroupCurveChart/GroupCurveChart.stories.tsx
@@ -15,6 +15,7 @@ export default {
 const Template: ComponentStory<typeof GroupCurveChart> = (args) => <GroupCurveChart {...args} />;
 
 export const Primary = Template.bind({});
+export const ScientificNotation = Template.bind({});
 export const Tooltip = Template.bind({});
 export const Crosshair = Template.bind({});
 export const TooltipWithCrosshair = Template.bind({});
@@ -49,6 +50,12 @@ Primary.args = {
   uncertainty: true,
   spectral: false,
   timePeriod: 100,
+};
+
+ScientificNotation.args = {
+  ...Primary.args,
+  yTickFormat: (v: number | { valueOf(): number }) => v.valueOf().toExponential(1),
+  heading: 'Group Curve Chart with Scientific Notation Y-Axis',
 };
 
 Tooltip.args = {

--- a/src/GroupCurveChart/GroupCurveChart.tsx
+++ b/src/GroupCurveChart/GroupCurveChart.tsx
@@ -45,7 +45,7 @@ const GroupCurveChart: React.FC<GroupCurveChartProps> = (props: GroupCurveChartP
     yTickFormat,
   } = props;
   const height = width * 0.75;
-  const marginLeft = 50;
+  const marginLeft = 60;
   const marginRight = 50;
   const marginTop = 50;
   const marginBottom = 50;

--- a/src/GroupCurveChart/GroupCurveChart.tsx
+++ b/src/GroupCurveChart/GroupCurveChart.tsx
@@ -42,6 +42,7 @@ const GroupCurveChart: React.FC<GroupCurveChartProps> = (props: GroupCurveChartP
     poe,
     uncertainty,
     timePeriod,
+    yTickFormat,
   } = props;
   const height = width * 0.75;
   const marginLeft = 50;
@@ -243,7 +244,7 @@ const GroupCurveChart: React.FC<GroupCurveChartProps> = (props: GroupCurveChartP
           <AxisLabel label={yLabel as string} width={width} height={height} orientation="left" />
           <Group left={marginLeft} top={marginTop}>
             <AxisBottom top={yMax} scale={xScale} numTicks={numTickX ?? autoNumTickX} stroke={gridColor} tickLength={3} tickStroke={gridColor} tickFormat={(v) => `${v.valueOf()}`} />
-            <AxisLeft scale={yScale} numTicks={numTickY ?? 5} stroke={gridColor} tickLength={3} tickStroke={gridColor} tickFormat={(v) => `${v.valueOf()}`} />
+            <AxisLeft scale={yScale} numTicks={numTickY ?? 5} stroke={gridColor} tickLength={3} tickStroke={gridColor} tickFormat={yTickFormat ?? ((v) => `${v.valueOf()}`)} />
             <GridColumns scale={xScale} width={xMax} height={yMax} stroke={gridColor ?? '#efefef'} />
             <GridRows scale={yScale} width={xMax} height={yMax} stroke={gridColor ?? '#efefef'} />
             <RectClipPath id="uncertainty-clip" height={yMax} width={xMax} />

--- a/src/GroupCurveChart/groupCurveChart.types.ts
+++ b/src/GroupCurveChart/groupCurveChart.types.ts
@@ -22,6 +22,7 @@ export interface GroupCurveChartProps {
   poe: number | undefined;
   uncertainty: boolean;
   timePeriod: number;
+  yTickFormat?: (v: number | { valueOf(): number }) => string;
 }
 
 export interface Curve {

--- a/src/GroupCurveChartResponsive/GroupCurveChartResponsive.stories.tsx
+++ b/src/GroupCurveChartResponsive/GroupCurveChartResponsive.stories.tsx
@@ -13,6 +13,7 @@ export default {
 const Template: ComponentStory<typeof GroupCurveChartResponsive> = (args) => <GroupCurveChartResponsive {...args} />;
 
 export const Primary = Template.bind({});
+export const ScientificNotation = Template.bind({});
 export const AutoXTick = Template.bind({});
 export const SpectralAccelUncertaintyTrue = Template.bind({});
 export const SpectralAccelUncertaintyFalse = Template.bind({});
@@ -34,6 +35,13 @@ Primary.args = {
   subHeading: 'WLG 250',
   poe: 0.02,
   timePeriod: 100,
+};
+
+ScientificNotation.args = {
+  ...Primary.args,
+  uncertainty: true,
+  yTickFormat: (v: number | { valueOf(): number }) => v.valueOf().toExponential(1),
+  heading: 'Hazard Chart with Scientific Notation Y-Axis',
 };
 
 AutoXTick.args = {

--- a/src/GroupCurveChartResponsive/GroupCurveChartResponsive.tsx
+++ b/src/GroupCurveChartResponsive/GroupCurveChartResponsive.tsx
@@ -22,6 +22,7 @@ export interface GroupCurveChartResponsiveProps {
   poe: number | undefined;
   uncertainty: boolean;
   timePeriod: number;
+  yTickFormat?: (v: number | { valueOf(): number }) => string;
 }
 
 const GroupCurveChartResponsive: React.FC<GroupCurveChartResponsiveProps> = (props: GroupCurveChartResponsiveProps) => {


### PR DESCRIPTION
closes #172 

- adds `yTickFormat` prop for scientific notation
- increase y-axis label spacing to left to avoid crowding 